### PR TITLE
[Clang][P1061] Remove BindingInitWalker

### DIFF
--- a/clang/include/clang/AST/Expr.h
+++ b/clang/include/clang/AST/Expr.h
@@ -1482,6 +1482,12 @@ public:
     setDependence(computeDependence(this, Context));
   }
 
+  /// Set type and compute and set dependence bits.
+  void setTypeFromBinding(QualType T, const ASTContext &Context) {
+    setType(T.getNonReferenceType());
+    setDependence(computeDependence(this, Context));
+  }
+
   static bool classof(const Stmt *T) {
     return T->getStmtClass() == DeclRefExprClass;
   }

--- a/clang/lib/Sema/SemaDeclCXX.cpp
+++ b/clang/lib/Sema/SemaDeclCXX.cpp
@@ -960,9 +960,8 @@ Sema::ActOnDecompositionDeclarator(Scope *S, Declarator &D,
 }
 
 // CheckBindingsCount
-//  - Checks the arity of the structured bindings
-//  - Creates the resolved pack expr if there is
-//    one
+//  - Check the arity of the structured bindings.
+//  - Create the resolved pack expr if needed.
 static bool CheckBindingsCount(Sema &S, DecompositionDecl *DD,
                                QualType DecompType,
                                ArrayRef<BindingDecl *> Bindings,
@@ -975,19 +974,30 @@ static bool CheckBindingsCount(Sema &S, DecompositionDecl *DD,
   if (!HasPack) {
     IsValid = Bindings.size() == MemberCount;
   } else {
-    // there may not be more members than non-pack bindings
+    // There may not be more members than non-pack bindings.
     IsValid = MemberCount >= Bindings.size() - 1;
   }
 
   if (IsValid && HasPack) {
-    // create the pack expr and assign it to the binding
+    // Create the pack expr and assign it to the binding.
     unsigned PackSize = MemberCount - Bindings.size() + 1;
     QualType PackType = S.Context.getPackExpansionType(
         S.Context.DependentTy, std::nullopt, /*ExpectsPackInType=*/false);
     BindingDecl *BD = (*BindingWithPackItr);
-    BD->setBinding(PackType,
-                   ResolvedUnexpandedPackExpr::Create(
-                       S.Context, DD->getBeginLoc(), DecompType, PackSize));
+    auto *RP = ResolvedUnexpandedPackExpr::Create(
+        S.Context, DD->getBeginLoc(), DecompType, PackSize);
+    BD->setBinding(PackType, RP);
+
+    BindingDecl *BPack = *BindingWithPackItr;
+    // Create the nested BindingDecls.
+    for (Expr *&E : RP->getExprs()) {
+      auto *NestedBD =
+          BindingDecl::Create(S.Context, BPack->getDeclContext(),
+                              BPack->getLocation(), BPack->getIdentifier(),
+                              QualType());
+      E = S.BuildDeclRefExpr(NestedBD, S.Context.DependentTy,
+                             VK_LValue, BPack->getLocation());
+    }
   }
 
   if (IsValid)
@@ -999,84 +1009,27 @@ static bool CheckBindingsCount(Sema &S, DecompositionDecl *DD,
   return true;
 }
 
-// BindingInitWalker
-//  - This implements a forward iterating flattened view
-//    of structured bindings that may have a nested pack.
-//    It allows the user to set the init expr for either the
-//    BindingDecl or its ResolvedUnexpandedPackExpr
-struct BindingInitWalker {
-  using BindingItrTy = typename ArrayRef<BindingDecl *>::iterator;
-  using PackExprItrTy = typename MutableArrayRef<Expr *>::iterator;
-  Sema &SemaRef;
-  DecompositionDecl *DecompDecl;
-  ArrayRef<BindingDecl *> Bindings;
-  ResolvedUnexpandedPackExpr *PackExpr = nullptr;
-  MutableArrayRef<Expr *> PackExprNodes;
-  BindingItrTy BindingItr;
-  PackExprItrTy PackExprItr;
-
-  BindingInitWalker(Sema &S, DecompositionDecl *DD, ArrayRef<BindingDecl *> Bs)
-      : SemaRef(S), DecompDecl(DD), Bindings(Bs), BindingItr(Bindings.begin()) {
-  }
-
-  BindingDecl *get() { return *BindingItr; }
-
-  void commitAndAdvance(QualType T, Expr *E) {
-    BindingDecl *B = *BindingItr;
-    bool IsPackExpr =
-        isa_and_nonnull<ResolvedUnexpandedPackExpr>(B->getBinding());
-    if (IsPackExpr && !PackExpr) {
-      PackExpr = cast<ResolvedUnexpandedPackExpr>(B->getBinding());
-      PackExprNodes = PackExpr->getExprs();
-      PackExprItr = PackExprNodes.begin();
-    }
-
-    if (IsPackExpr) {
-      // Build a nested BindingDecl with a DeclRefExpr
-      auto *NestedBD =
-          BindingDecl::Create(SemaRef.Context, B->getDeclContext(),
-                              B->getLocation(), B->getIdentifier(), T);
-
-      NestedBD->setBinding(T, E);
-      NestedBD->setDecomposedDecl(DecompDecl);
-      auto *DE = SemaRef.BuildDeclRefExpr(NestedBD, T.getNonReferenceType(),
-                                          VK_LValue, B->getLocation());
-      *PackExprItr = DE;
-      if (++PackExprItr != PackExprNodes.end())
-        return;
-      // If we hit the end of the pack exprs then
-      // continue to advance BindingItr
-    } else {
-      (*BindingItr)->setBinding(T, E);
-    }
-
-    ++BindingItr;
-  }
-};
-
 static bool checkSimpleDecomposition(
     Sema &S, ArrayRef<BindingDecl *> Bindings, ValueDecl *Src,
     QualType DecompType, const llvm::APSInt &NumElemsAPS, QualType ElemType,
     llvm::function_ref<ExprResult(SourceLocation, Expr *, unsigned)> GetInit) {
   unsigned NumElems = (unsigned)NumElemsAPS.getLimitedValue(UINT_MAX);
+  auto *DD = cast<DecompositionDecl>(Src);
 
-  if (CheckBindingsCount(S, cast<DecompositionDecl>(Src), DecompType, Bindings,
-                         NumElems)) {
-
+  if (CheckBindingsCount(S, DD, DecompType, Bindings, NumElems))
     return true;
-  }
 
-  auto Walker = BindingInitWalker(S, cast<DecompositionDecl>(Src), Bindings);
-  for (unsigned I = 0; I < NumElems; I++) {
-    BindingDecl *B = Walker.get();
+  unsigned I = 0;
+  for (auto *B : DD->flat_bindings()) {
     SourceLocation Loc = B->getLocation();
     ExprResult E = S.BuildDeclRefExpr(Src, DecompType, VK_LValue, Loc);
     if (E.isInvalid())
       return true;
-    E = GetInit(Loc, E.get(), I);
+    E = GetInit(Loc, E.get(), I++);
     if (E.isInvalid())
       return true;
-    Walker.commitAndAdvance(ElemType, E.get());
+    B->setDecomposedDecl(DD);
+    B->setBinding(ElemType, E.get());
   }
 
   return false;
@@ -1314,11 +1267,10 @@ static bool checkTupleLikeDecomposition(Sema &S,
                                         ArrayRef<BindingDecl *> Bindings,
                                         VarDecl *Src, QualType DecompType,
                                         const llvm::APSInt &TupleSize) {
+  auto *DD = cast<DecompositionDecl>(Src);
   unsigned NumElems = (unsigned)TupleSize.getLimitedValue(UINT_MAX);
-  if (CheckBindingsCount(S, cast<DecompositionDecl>(Src), DecompType, Bindings,
-                         NumElems)) {
+  if (CheckBindingsCount(S, DD, DecompType, Bindings, NumElems))
     return true;
-  }
 
   if (Bindings.empty())
     return false;
@@ -1351,9 +1303,8 @@ static bool checkTupleLikeDecomposition(Sema &S,
     }
   }
 
-  auto Walker = BindingInitWalker(S, cast<DecompositionDecl>(Src), Bindings);
-  for (unsigned I = 0; I < NumElems; I++) {
-    BindingDecl *B = Walker.get();
+  unsigned I = 0;
+  for (auto *B : DD->flat_bindings()) {
     InitializingBinding InitContext(S, B);
     SourceLocation Loc = B->getLocation();
 
@@ -1439,7 +1390,9 @@ static bool checkTupleLikeDecomposition(Sema &S,
     if (E.isInvalid())
       return true;
 
-    Walker.commitAndAdvance(T, E.get());
+    B->setDecomposedDecl(DD);
+    B->setBinding(T, E.get());
+    I++;
   }
 
   return false;
@@ -1535,18 +1488,18 @@ static bool checkMemberDecomposition(Sema &S, ArrayRef<BindingDecl*> Bindings,
   QualType BaseType = S.Context.getQualifiedType(S.Context.getRecordType(RD),
                                                  DecompType.getQualifiers());
 
+  auto *DD = cast<DecompositionDecl>(Src);
   unsigned NumFields = llvm::count_if(
       RD->fields(), [](FieldDecl *FD) { return !FD->isUnnamedBitField(); });
-  if (CheckBindingsCount(S, cast<DecompositionDecl>(Src), DecompType, Bindings,
-                         NumFields)) {
+  if (CheckBindingsCount(S, DD, DecompType, Bindings, NumFields))
     return true;
-  }
-
-  auto Walker = BindingInitWalker(S, cast<DecompositionDecl>(Src), Bindings);
 
   //   all of E's non-static data members shall be [...] well-formed
   //   when named as e.name in the context of the structured binding,
   //   E shall not have an anonymous union member, ...
+  auto FlatBindings = DD->flat_bindings();
+  assert(llvm::range_size(FlatBindings) == NumFields);
+  auto FlatBindingsItr = FlatBindings.begin();
   for (auto *FD : RD->fields()) {
     if (FD->isUnnamedBitField())
       continue;
@@ -1571,7 +1524,8 @@ static bool checkMemberDecomposition(Sema &S, ArrayRef<BindingDecl*> Bindings,
     }
 
     // We have a real field to bind.
-    BindingDecl *B = Walker.get();
+    assert(FlatBindingsItr != FlatBindings.end());
+    BindingDecl* B = *(FlatBindingsItr++);
     SourceLocation Loc = B->getLocation();
 
     // The field must be accessible in the context of the structured binding.
@@ -1606,8 +1560,7 @@ static bool checkMemberDecomposition(Sema &S, ArrayRef<BindingDecl*> Bindings,
     Qualifiers Q = DecompType.getQualifiers();
     if (FD->isMutable())
       Q.removeConst();
-    Walker.commitAndAdvance(S.BuildQualifiedType(FD->getType(), Loc, Q),
-                            E.get());
+    B->setBinding(S.BuildQualifiedType(FD->getType(), Loc, Q), E.get());
   }
 
   return false;
@@ -1625,6 +1578,19 @@ void Sema::CheckCompleteDecompositionDeclaration(DecompositionDecl *DD) {
         B->setType(Context.DependentTy);
     }
     return;
+  } else {
+    // Set the types of the DeclRefExprs that point to nested pack bindings.
+    for (BindingDecl *B : DD->bindings()) {
+      if (B->isParameterPack()) {
+        for (Expr *E : B->getBindingPackExprs()) {
+          auto *DRE = cast<DeclRefExpr>(E);
+          auto *NestedB = cast<BindingDecl>(DRE->getDecl());
+          QualType T = NestedB->getType();
+          DRE->setTypeFromBinding(T, Context);
+        }
+        break;
+      }
+    }
   }
 
   DecompType = DecompType.getNonReferenceType();


### PR DESCRIPTION
Here is an implementation that removes the `BindingInitWalker`. Notice that we have to go back and add the type to each `DeclRefExpr` that points to a nested `BindinDecl`. Let me know, and I will just put this commit in the main p1061 PR.